### PR TITLE
Make baseurl configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,9 @@ RECHARGE_STOREFRONT_DOMAIN=your-shop.myshopify.com
 # Required: Admin API token for session creation
 RECHARGE_ADMIN_TOKEN=your_admin_api_token_here
 
+# Optional: Recharge API URL (defaults to production)
+RECHARGE_API_URL=https://api.rechargeapps.com
+
 # Optional: Default customer session token (if you have one)
 RECHARGE_SESSION_TOKEN=
 
@@ -563,6 +566,7 @@ DEBUG=true
 |----------|----------|-------------|---------|
 | `RECHARGE_STOREFRONT_DOMAIN` | Yes* | Your Shopify domain | `shop.myshopify.com` |
 | `RECHARGE_ADMIN_TOKEN` | Yes* | Admin API token for session creation | `your_admin_api_token_here` |
+| `RECHARGE_API_URL` | No | Recharge API endpoint (defaults to production) | `https://api.stage.rechargeapps.com` |
 | `RECHARGE_SESSION_TOKEN` | No | Default customer session token | `st_abc123` |
 | `MCP_SERVER_NAME` | No | Server identification | `recharge-mcp` |
 | `MCP_SERVER_VERSION` | No | Server version | `1.0.0` |

--- a/src/recharge-client.js
+++ b/src/recharge-client.js
@@ -32,9 +32,12 @@ export class RechargeClient {
     this.adminToken = adminToken;
     this.sessionCache = new SessionCache();
 
+    // Get API URL from environment variable or use production default
+    const apiUrl = process.env.RECHARGE_API_URL || 'https://api.rechargeapps.com';
+
     // Create axios instances
     this.storefrontApi = axios.create({
-      baseURL: 'https://api.rechargeapps.com',
+      baseURL: apiUrl,
       timeout: 30000,
       headers: {
         'Content-Type': 'application/json',
@@ -43,7 +46,7 @@ export class RechargeClient {
     });
 
     this.adminApi = axios.create({
-      baseURL: 'https://api.rechargeapps.com',
+      baseURL: apiUrl,
       timeout: 30000,
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
This MR maintains the default production URL while allowing a user to override it with another environment URL using `RECHARGE_API_URL`.